### PR TITLE
fix(deps): bump pytest to ^9.0.3 to patch CVE-2025-71176

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ authors = ["yuan <yuanz271@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 torch = ">=1.9.0"
 scipy = ">=1.7.0"
 numpy = ">=1.21.0"
 tqdm = ">=4.61.2"
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.4"
+pytest = "^9.0.3"
 matplotlib = "^3.4.2"
 scikit-learn = "^1.0.1"
 yapf = "^0.31.0"


### PR DESCRIPTION
## Summary
- Bumps `pytest` from `^6.2.4` to `^9.0.3`, closing Dependabot alert [#2](https://github.com/catniplab/vjf/security/dependabot/2) ([CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) / [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) — insecure `/tmp/pytest-of-{user}` permissions, CWE-379).
- Bumps the project's Python floor from `>=3.8` to `>=3.10` (required by pytest 9; Python 3.8 and 3.9 are both EOL).

## Rationale
The CVE has no backport — only pytest 9.0.3+ is patched. Since pytest is a dev-dependency only, the install-time impact on library users is the Python floor bump. Python 3.8 reached EOL in 2024-10 and 3.9 in 2025-10, so this is a low-risk floor.

## Test plan
- [x] `pytest 9.0.3` installs cleanly with the rest of the runtime stack (torch, scipy, numpy, tqdm) on Python 3.10.
- [x] Test suite shows no regression vs. master: same 4 tests pass / 2 tests fail with both pytest 6.2.4 and pytest 9.0.3.
- [x] The two failing tests (`test_Recognition`, `test_sgp`) are pre-existing and unrelated — `test_sgp` imports `vjf.gp` which was removed in 09cba0a, and `test_Recognition` calls a stale `Recognition(...)` signature. Both should be cleaned up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)